### PR TITLE
Nuevo recurso: Guía básica para Sinatra

### DIFF
--- a/_common/unclassified.md
+++ b/_common/unclassified.md
@@ -14,3 +14,4 @@ layout: resource
 [Install TeXlive on Ubuntu - Scott Kostyshak](https://github.com/scottkosty/install-tl-ubuntu) - *Un script para la instalación de TeXlive en Ubuntu*
 
 [LaTeX cheatsheet](http://users.dickinson.edu/~richesod/latex/latexcheatsheet.pdf) - *Breve resumen de los comandos y expresiones más usuales en LaTeX*
+[Guía básica para Sinatra - Autores de Sinatra](http://www.sinatrarb.com/intro.html)  


### PR DESCRIPTION
Añade _[Guía básica para Sinatra](http://www.sinatrarb.com/intro.html)_ de Autores de Sinatra.
