### PR TITLE
Añade autores y más apuntes

### DIFF
--- a/apuntes.md
+++ b/apuntes.md
@@ -23,15 +23,47 @@ Aún no hay apuntes.
 
 ## Segundo curso
 
-- [Álgebra I](https://github.com/libreim/apuntesDGIIM/wiki/Apuntes-en-PDF) ([fuentes](https://github.com/libreim/apuntesDGIIM/tree/master/%C3%81lgebra%20I))
-- [Análisis Matemático I](https://github.com/libreim/apuntesDGIIM/wiki/Apuntes-en-PDF) ([fuentes](https://github.com/libreim/apuntesDGIIM/tree/master/An%C3%A1lisis%20Matem%C3%A1tico%20I))
-- [Estructuras de Datos](https://github.com/libreim/apuntesDGIIM/wiki/Apuntes-en-PDF) ([fuentes](https://github.com/libreim/apuntesDGIIM/tree/master/Estructura%20de%20datos))
-- [Sistemas Operativos](https://github.com/libreim/apuntesDGIIM/wiki/Apuntes-en-PDF) ([fuentes](https://github.com/libreim/apuntesDGIIM/tree/master/Sistemas%20Operativos))
+### Álgebra I
+
+ - [Álgebra I - pdf](https://github.com/libreim/apuntesDGIIM/wiki/Apuntes-en-PDF) 
+ - [Código fuente](https://github.com/libreim/apuntesDGIIM/tree/master/%C3%81lgebra%20I) 
+ 
+Escritos por Javier Sáez, Daniel Pozo, Pedro Bonilla, Guillermo Galindo, Antonio Coín y Sofía Almeida.
+
+### Análisis Matemático I
+ 
+ - [Análisis Matemático I](https://github.com/libreim/apuntesDGIIM/wiki/Apuntes-en-PDF) 
+ - [Código fuente](https://github.com/libreim/apuntesDGIIM/tree/master/An%C3%A1lisis%20Matem%C3%A1tico%20I)
+
+Escritos por Javier Sáez, Daniel Pozo, Pedro Bonilla, Guillermo Galindo, Antonio Coín y Sofía Almeida.
+
+### Estructuras de Datos
+
+ - [Estructuras de Datos](https://github.com/libreim/apuntesDGIIM/wiki/Apuntes-en-PDF)
+ - [Código fuente](https://github.com/libreim/apuntesDGIIM/tree/master/Estructura%20de%20datos)
+
+Escritos por Javier Sáez, Daniel Pozo y Jesús.
+
+### Sistemas Operativos
+
+ - [Sistemas Operativos](https://github.com/libreim/apuntesDGIIM/wiki/Apuntes-en-PDF) 
+ - [Código fuente](https://github.com/libreim/apuntesDGIIM/tree/master/Sistemas%20Operativos)
+
+Escritos por Javier Sáez, Daniel Pozo, Pedro Bonilla, Guillermo Galindo, Antonio Coín, Sofía Almeida, Jesús y José María Martín.
 
 ## Tercer curso
+### Probabilidad
+ - [Probabilidad](https://github.com/libreim/Probabilidad-I-DGIIM/blob/master/build/apuntes.pdf)
+ - [Código fuente](https://github.com/libreim/Probabilidad-I-DGIIM/blob/master/apuntes.tex)
 
-- [Probabilidad](https://github.com/libreim/Probabilidad-I-DGIIM/blob/master/build/apuntes.pdf) ([fuentes](https://github.com/libreim/Probabilidad-I-DGIIM/blob/master/apuntes.tex))
-- [Álgebra II](https://github.com/libreim/apuntesalgebraii/blob/master/apuntesalgebraii/algebra2.pdf) ([fuentes](https://github.com/libreim/apuntesalgebraii/blob/master/apuntesalgebraii/algebra2.tex))
+Escritos por Francisco Luque, Braulio Valdivielso, Santiago De Diego.
+
+### Álgebra II
+
+ - [Álgebra II](https://github.com/libreim/apuntesalgebraii/blob/master/apuntesalgebraii/algebra2.pdf) 
+ - [Código fuente](https://github.com/libreim/apuntesalgebraii/blob/master/apuntesalgebraii/algebra2.tex))
+
+Escritos por Rodrigo Raya desde las clases de Pilar Carrasco (UGR).
 
 ## Cuarto curso
 
@@ -42,5 +74,8 @@ Aún no hay apuntes.
 Aún no hay apuntes.
 
 ## Apuntes adicionales
+### Teoría de la Información
 
-- [Teoría de la Información (Shannon-Kolmogorov)](https://github.com/libreim/shannon-kolmogorov)
+ - [Teoría de la Información (código fuente)](https://github.com/libreim/shannon-kolmogorov)
+
+Apuntes de Nicolò Cesa-Bianchi (UNIMI) traducidos por Mario Román.

--- a/apuntes.md
+++ b/apuntes.md
@@ -13,7 +13,7 @@ article .post-data a.backtomain { display: none; }
 ¿Buscabas el [repositorio colaborativo de apuntes del Doble Grado](https://libreim.github.io/apuntesDGIIM/)?
 {:.fig}
 
-En esta sección recopilamos apuntes de asignaturas de Informática y Matemáticas redactados por estudiantes.
+En esta sección recopilamos apuntes de asignaturas de Informática y Matemáticas abiertos y con licencias libres redactados por estudiantes.
 
 Si tienes unos apuntes y quieres que aparezcan en esta lista, [edítala](https://github.com/libreim/awesome/edit/gh-pages/apuntes.md) añadiendo un enlace también al código fuente en caso de estar redactados en LaTeX, Markdown u otros lenguajes de composición. También puedes usar el [formulario de envío de recursos](http://tux.ugr.es/libreim/new/resource/), indicando que se trata de apuntes. Recuerda asociarlos a una licencia libre (por ejemplo, de tipo [Creative Commons](https://creativecommons.org/choose/)) para que los compañeros puedan compartirlo.
 

--- a/apuntes.md
+++ b/apuntes.md
@@ -78,8 +78,12 @@ Aún no hay apuntes.
 
 ## Asignaturas optativas
 
-Aún no hay apuntes.
+### Álgebra Conmutativa y Computacional
 
+ - [Álgebra Conmutativa y Computacional](https://libreim.github.io/abstract-algebra/conmutativa.html)
+ - [Código fuente](https://github.com/libreim/abstract-algebra/blob/master/conmutativa.org)
+
+Escritos por Mario Román desde las clases de Pilar Carrasco (UGR).
 ## Apuntes adicionales
 
 ### Algoritmos Genéticos

--- a/apuntes.md
+++ b/apuntes.md
@@ -92,3 +92,10 @@ Escritos por Andrés Herrera.
  - [Teoría de la Información (código fuente)](https://github.com/libreim/shannon-kolmogorov)
 
 Apuntes de Nicolò Cesa-Bianchi (UNIMI) traducidos por Mario Román.
+
+### Aprendizaje PAC
+
+  - [Aprendizaje PAC](https://github.com/libreim/PAC-learning/blob/master/introduccion.pdf)
+  - [Código fuente](https://github.com/libreim/PAC-learning)
+  
+Escritos por Ignacio Cordón.

--- a/apuntes.md
+++ b/apuntes.md
@@ -47,17 +47,19 @@ Escritos por Javier Sáez, Daniel Pozo, Pedro Bonilla, Guillermo Galindo, Antoni
  - [Estructuras de Datos](https://github.com/libreim/apuntesDGIIM/wiki/Apuntes-en-PDF)
  - [Código fuente](https://github.com/libreim/apuntesDGIIM/tree/master/Estructura%20de%20datos)
 
-Escritos por Javier Sáez, Daniel Pozo y Jesús.
+Escritos por Javier Sáez, Daniel Pozo y Jesús Sánchez.
 
 ### Sistemas Operativos
 
  - [Sistemas Operativos](https://github.com/libreim/apuntesDGIIM/wiki/Apuntes-en-PDF) 
  - [Código fuente](https://github.com/libreim/apuntesDGIIM/tree/master/Sistemas%20Operativos)
 
-Escritos por Javier Sáez, Daniel Pozo, Pedro Bonilla, Guillermo Galindo, Antonio Coín, Sofía Almeida, Jesús y José María Martín.
+Escritos por Javier Sáez, Daniel Pozo, Pedro Bonilla, Guillermo Galindo, Antonio Coín, Sofía Almeida, Jesús Sánchez y José María Martín.
 
 ## Tercer curso
+
 ### Probabilidad
+
  - [Probabilidad](https://github.com/libreim/Probabilidad-I-DGIIM/blob/master/build/apuntes.pdf)
  - [Código fuente](https://github.com/libreim/Probabilidad-I-DGIIM/blob/master/apuntes.tex)
 

--- a/apuntes.md
+++ b/apuntes.md
@@ -19,8 +19,13 @@ Si tienes unos apuntes y quieres que aparezcan en esta lista, [edítala](https:/
 
 ## Primer curso
 
-Aún no hay apuntes.
+### Cálculo I
 
+ - [Cálculo Diferencial e Integral](http://www.ugr.es/%7Efjperez/apuntes.html)
+ - [Código fuente](https://github.com/libreim/calculo)
+ 
+Escritos por Francisco Javier Pérez (UGR).
+ 
 ## Segundo curso
 
 ### Álgebra I
@@ -74,6 +79,14 @@ Aún no hay apuntes.
 Aún no hay apuntes.
 
 ## Apuntes adicionales
+
+### Algoritmos Genéticos
+
+ - [Algoritmos Genéticos](https://github.com/libreim/AlgoritmosGeneticos/blob/master/AlgoritmosGeneticos.pdf)
+ - [Código fuente](https://github.com/libreim/AlgoritmosGeneticos)
+
+Escritos por Andrés Herrera.
+
 ### Teoría de la Información
 
  - [Teoría de la Información (código fuente)](https://github.com/libreim/shannon-kolmogorov)


### PR DESCRIPTION
Añade el listado de autores, diferencia entre enlaces al código y al pdf y añade autores.

Sería necesario comprobar que no faltan autores (especialmente en los enlaces a apuntesDGIIM, donde los he tomado del fuente o de los commits que he encontrado); y añadir, en los casos necesarios, a los profesores de cuyas clases o apuntes han salido los apuntes.